### PR TITLE
Updates mu repo name

### DIFF
--- a/repos.md
+++ b/repos.md
@@ -327,7 +327,7 @@
 - higherkindness/compendium
 - higherkindness/compendium-example
 - higherkindness/droste
-- higherkindness/mu
+- higherkindness/mu-scala
 - higherkindness/mu-client.g8
 - higherkindness/mu-server.g8
 - higherkindness/sbt-compendium


### PR DESCRIPTION
It has been recently renamed to [mu-scala](https://github.com/higherkindness/mu-scala).

Thank you.